### PR TITLE
docs(homepage): fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
                       href="https://the-agent-company.com/"
                       class="external-link button is-normal is-rounded is-dark"
                     >
-                    <span>Our new benchmark TheAgentComanpy!</span>
+                    <span>Our new benchmark TheAgentCompany!</span>
                     </a>
                   </span>
                 </div>


### PR DESCRIPTION
There is a minor spelling mistake on one of the buttons in index.html, `TheAgentComanpy!` --> `TheAgentCompany!`